### PR TITLE
[1.x] Reworks and extends Form Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,38 @@ Route::post('comment', function (TurnstileRequest $request) {
 > 
 > The Request will check for the `cf-turnstile-response` key [by default](#form-key), plus a successful Challenge. If you need more fine-tuning, consider using the [middleware](#validating-with-middleware), [rule](#validating-with-rule), or [validating manually](#validating-manually).
 
+#### Extending the Form Request
+
+If you need to create a form request and also validate the Turnstile Challenge, you may safely extend the `TurnstileRequest` instead. The class runs the validation _before_ your form request authorization and rules.
+
+```php
+namespace App\Http\Requests;
+
+use Laragear\Turnstile\Http\Requests\TurnstileRequest;
+
+class CommentStoreRequest extends TurnstileRequest
+{
+    public function rules(): array
+    {
+        return [
+            'body' => 'required|string'
+        ];
+    }
+}
+```
+
+This means your controller can safely retrieve the validated data using `$request->validated()`.
+
+```php
+use App\Models\Comment;
+use Illuminate\Support\Facades\Route;
+use App\Http\Requests\CommentStoreRequest;
+
+Route::post('comment', function (CommentStoreRequest $request) {
+    return Comment::create($request->validated());
+})
+```
+
 ### Validating with Middleware
 
 The `turnstile` middleware is a great way to check if a form submission contains a successful challenge. Simply add the middleware to the route (or group of routes) that receive the form submission, like a `POST`, `PUT` or `PATCH`. 

--- a/src/Http/Requests/TurnstileRequest.php
+++ b/src/Http/Requests/TurnstileRequest.php
@@ -28,4 +28,56 @@ class TurnstileRequest extends FormRequest
     {
         return $this->container->make(Challenge::class);
     }
+
+    /**
+     * Returns a metadata value using a key in `dot.notation`.
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function metadata(string $key, mixed $default = null): mixed
+    {
+        return $this->challenge()->metadata($key, $default);
+    }
+
+    /**
+     * Check if the action is the same as the developer expects.
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function isAction(string $action): bool
+    {
+        return $this->challenge()->isAction($action);
+    }
+
+    /**
+     * Check if the action is not the same as the developer expects.
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function isNotAction(string $action): bool
+    {
+        return $this->challenge()->isNotAction($action);
+    }
+
+    /**
+     * Checks if the Customer Data is the same pattern as the developer expects.
+     *
+     * @param  string|iterable<string>  $customerData
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function isCustomerData(string|iterable $customerData): bool
+    {
+        return $this->challenge()->isCustomerData($customerData);
+    }
+
+    /**
+     * Checks if the Customer Data is not the same pattern as the developer expects.
+     *
+     * @param  string|iterable<string>  $customerData
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function isNotCustomerData(string|iterable $customerData): bool
+    {
+        return $this->challenge()->isNotCustomerData($customerData);
+    }
 }

--- a/src/Http/Requests/TurnstileRequest.php
+++ b/src/Http/Requests/TurnstileRequest.php
@@ -9,14 +9,16 @@ use Laragear\Turnstile\Turnstile;
 class TurnstileRequest extends FormRequest
 {
     /**
-     * Prepare the data for validation.
+     * Validate the class instance.
      *
      * @return void
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function prepareForValidation(): void
+    public function validateResolved(): void
     {
         $this->checkTurnstileChallenge();
+
+        parent::validateResolved();
     }
 
     /**

--- a/src/Http/Requests/TurnstileRequest.php
+++ b/src/Http/Requests/TurnstileRequest.php
@@ -9,14 +9,43 @@ use Laragear\Turnstile\Turnstile;
 class TurnstileRequest extends FormRequest
 {
     /**
-     * Get the validation rules that apply to the request.
+     * Handle a passed validation attempt.
      *
-     * @return array<string, string>
+     * @return void
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function rules(): array
+    protected function passedValidation(): void
     {
-        return $this->container->make(Turnstile::class)->rules();
+        $this->checkTurnstileChallenge();
+    }
+
+    /**
+     * Checks if the Cloudflare Turnstile challenge is valid through the validation rule.
+     *
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    protected function checkTurnstileChallenge(): void
+    {
+        /** @var \Laragear\Turnstile\Turnstile $turnstile */
+        $turnstile = $this->container->make(Turnstile::class);
+
+        // We are going to copy-and-paste the "getValidatorInstance" but using our data and rules.
+        /** @var \Illuminate\Contracts\Validation\Factory $factory */
+        $factory = $this->container->make('validator');
+
+        $validator = $factory->make(
+            $this->only($turnstile->key()),
+            $turnstile->rules(),
+            $this->messages(),
+            $this->attributes(),
+        )->stopOnFirstFailure();
+
+        if ($this->isPrecognitive()) {
+            $validator->setRules($this->filterPrecognitiveRules($validator->getRulesWithoutPlaceholders()));
+        }
+
+        $validator->validate();
     }
 
     /**

--- a/src/Http/Requests/TurnstileRequest.php
+++ b/src/Http/Requests/TurnstileRequest.php
@@ -36,7 +36,7 @@ class TurnstileRequest extends FormRequest
         /** @var \Illuminate\Contracts\Validation\Factory $factory */
         $factory = $this->container->make('validator');
 
-        $validator = $factory->make(
+        $validator = $factory->make( // @phpstan-ignore-line
             $this->only($turnstile->key()),
             $turnstile->rules(),
             $this->messages(),

--- a/src/Http/Requests/TurnstileRequest.php
+++ b/src/Http/Requests/TurnstileRequest.php
@@ -9,12 +9,12 @@ use Laragear\Turnstile\Turnstile;
 class TurnstileRequest extends FormRequest
 {
     /**
-     * Handle a passed validation attempt.
+     * Prepare the data for validation.
      *
      * @return void
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function passedValidation(): void
+    protected function prepareForValidation(): void
     {
         $this->checkTurnstileChallenge();
     }

--- a/tests/Http/Requests/TurnstileRequestTest.php
+++ b/tests/Http/Requests/TurnstileRequestTest.php
@@ -71,6 +71,7 @@ class TurnstileRequestTest extends TestCase
     {
         $this->mock(Turnstile::class, function (MockInterface $mock) {
             $mock->expects('isDisabled')->andReturnFalse();
+            $mock->expects('key')->andReturn(Turnstile::KEY);
             $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
             $mock->expects('getChallenge')->andReturn( new Challenge(
                 false, '', '', '', [], [], new Carbon()
@@ -90,6 +91,7 @@ class TurnstileRequestTest extends TestCase
     {
         $this->mock(Turnstile::class, function (MockInterface $mock) {
             $mock->expects('isDisabled')->andReturnFalse();
+            $mock->expects('key')->andReturn(Turnstile::KEY);
             $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
             $mock->expects('getChallenge')->andReturn( new Challenge(
                 false, '', '', '', [], [], new Carbon()

--- a/tests/Http/Requests/TurnstileRequestTest.php
+++ b/tests/Http/Requests/TurnstileRequestTest.php
@@ -16,7 +16,7 @@ class TurnstileRequestTest extends TestCase
 {
     protected function defineRoutes($router): void
     {
-        $router->post('test', static function(TurnstileRequest $request): bool {
+        $router->post('test', static function (TurnstileRequest $request): bool {
             return $request->challenge()->success;
         });
     }
@@ -26,7 +26,7 @@ class TurnstileRequestTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         TurnstileRequest::create(
-            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key'],
         )->setContainer($this->app)->validateResolved();
     }
 
@@ -35,7 +35,7 @@ class TurnstileRequestTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         TurnstileRequest::create(uri: '/', method: 'POST', server: [
-                'CONTENT_TYPE' => 'application/json',
+            'CONTENT_TYPE' => 'application/json',
         ], content: json_encode([Turnstile::KEY => 'test_key']))
             ->setContainer($this->app)
             ->setRedirector($this->app->make('redirect'))
@@ -51,7 +51,7 @@ class TurnstileRequestTest extends TestCase
             [1],
             [1.0],
             [[]],
-            ['']
+            [''],
         ];
     }
 
@@ -73,8 +73,8 @@ class TurnstileRequestTest extends TestCase
             $mock->expects('isDisabled')->andReturnFalse();
             $mock->expects('key')->andReturn(Turnstile::KEY);
             $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
-            $mock->expects('getChallenge')->andReturn( new Challenge(
-                false, '', '', '', [], [], new Carbon()
+            $mock->expects('getChallenge')->andReturn(new Challenge(
+                false, '', '', '', [], [], new Carbon(),
             ));
         });
 
@@ -93,8 +93,8 @@ class TurnstileRequestTest extends TestCase
             $mock->expects('isDisabled')->andReturnFalse();
             $mock->expects('key')->andReturn(Turnstile::KEY);
             $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
-            $mock->expects('getChallenge')->andReturn( new Challenge(
-                false, '', '', '', [], [], new Carbon()
+            $mock->expects('getChallenge')->andReturn(new Challenge(
+                false, '', '', '', [], [], new Carbon(),
             ));
         });
 
@@ -112,13 +112,13 @@ class TurnstileRequestTest extends TestCase
     public function test_metadata(): void
     {
         $request = TurnstileRequest::create(
-            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key'],
         )->setContainer($this->app);
 
         $request->validateResolved();
 
         $this->app->instance(
-            Challenge::class, new Challenge(true, '', '', '', ['foo' => ['bar' => 'baz']], [], new Carbon())
+            Challenge::class, new Challenge(true, '', '', '', ['foo' => ['bar' => 'baz']], [], new Carbon()),
         );
 
         static::assertSame('baz', $request->metadata('foo.bar'));
@@ -127,13 +127,13 @@ class TurnstileRequestTest extends TestCase
     public function test_action(): void
     {
         $request = TurnstileRequest::create(
-            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key'],
         )->setContainer($this->app);
 
         $request->validateResolved();
 
         $this->app->instance(
-            Challenge::class, new Challenge(true, '', 'test_action', '', [], [], new Carbon())
+            Challenge::class, new Challenge(true, '', 'test_action', '', [], [], new Carbon()),
         );
 
         static::assertTrue($request->isAction('test_action'));
@@ -143,16 +143,70 @@ class TurnstileRequestTest extends TestCase
     public function test_customer_data(): void
     {
         $request = TurnstileRequest::create(
-            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key'],
         )->setContainer($this->app);
 
         $request->validateResolved();
 
         $this->app->instance(
-            Challenge::class, new Challenge(true, '', '', 'test_cdata', [], [], new Carbon())
+            Challenge::class, new Challenge(true, '', '', 'test_cdata', [], [], new Carbon()),
         );
 
         static::assertTrue($request->isCustomerData('test_cdata'));
         static::assertFalse($request->isNotCustomerData('test_cdata'));
+    }
+
+    public function test_extending_form_request_validates_turnstile_before_rules(): void
+    {
+        $request = TestTurnstileRequest::create(
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key', 'test' => 'value'],
+        )->setContainer($this->app);
+
+        $request->validateResolved();
+
+        static::assertSame(['test' => 'value'], $request->validated());
+    }
+
+    public function test_challenge_error_runs_before_rules(): void
+    {
+        $this->mock(Turnstile::class, function (MockInterface $mock) {
+            $mock->expects('isDisabled')->andReturnFalse();
+            $mock->expects('key')->andReturn(Turnstile::KEY);
+            $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
+            $mock->expects('getChallenge')->andReturn(new Challenge(
+                false, '', '', '', [], [], new Carbon(),
+            ));
+        });
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The Cloudflare Turnstile challenge is invalid, absent, or has failed.');
+
+        $request = TestTurnstileRequest::create(uri: '/', method: 'POST', server: [
+            'CONTENT_TYPE' => 'application/json',
+        ], content: json_encode([Turnstile::KEY => 'invalid']))
+            ->setContainer($this->app)
+            ->setRedirector($this->app->make('redirect'));
+
+        try {
+            $request->validateResolved();
+        } catch (ValidationException $e) {
+            static::assertFalse($request->rulesWasAsked);
+
+            throw $e;
+        }
+    }
+}
+
+class TestTurnstileRequest extends TurnstileRequest
+{
+    public bool $rulesWasAsked = false;
+
+    public function rules(): array
+    {
+        $this->rulesWasAsked = true;
+
+        return [
+            'test' => 'required|string'
+        ];
     }
 }

--- a/tests/Http/Requests/TurnstileRequestTest.php
+++ b/tests/Http/Requests/TurnstileRequestTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Http\Requests;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Validation\ValidationException;
 use Laragear\Turnstile\Challenge;
 use Laragear\Turnstile\Http\Requests\TurnstileRequest;
 use Laragear\Turnstile\Turnstile;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
+use function json_encode;
 
 class TurnstileRequestTest extends TestCase
 {
@@ -20,34 +23,134 @@ class TurnstileRequestTest extends TestCase
 
     public function test_request_passes(): void
     {
-        $this->post('test', [Turnstile::KEY => 'test_key'])->assertStatus(200)->assertSee('1');
+        $this->expectNotToPerformAssertions();
+
+        TurnstileRequest::create(
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+        )->setContainer($this->app)->validateResolved();
     }
 
     public function test_request_json_passes(): void
     {
-        $this->postJson('test', [Turnstile::KEY => 'test_key'])->assertStatus(200)->assertSee('1');
+        $this->expectNotToPerformAssertions();
+
+        TurnstileRequest::create(uri: '/', method: 'POST', server: [
+                'CONTENT_TYPE' => 'application/json',
+        ], content: json_encode([Turnstile::KEY => 'test_key']))
+            ->setContainer($this->app)
+            ->setRedirector($this->app->make('redirect'))
+            ->validateResolved();
+    }
+
+    public static function provideInvalidValues(): array
+    {
+        return [
+            [null],
+            [true],
+            [false],
+            [1],
+            [1.0],
+            [[]],
+            ['']
+        ];
+    }
+
+    #[DataProvider('provideInvalidValues')]
+    public function test_request_throws_validation_error_if_invalid_scalars(mixed $value): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The Cloudflare Turnstile challenge is invalid, absent, or has failed.');
+
+        TurnstileRequest::create(uri: '/', method: 'POST', parameters: [Turnstile::KEY => $value])
+            ->setContainer($this->app)
+            ->setRedirector($this->app->make('redirect'))
+            ->validateResolved();
     }
 
     public function test_request_throws_validation_error_on_failed_challenge(): void
     {
         $this->mock(Turnstile::class, function (MockInterface $mock) {
-            $mock->expects('isDisabled')->twice()->andReturnFalse();
-            $mock->expects('rules')->twice()->andReturn([Turnstile::KEY => 'turnstile']);
-            $mock->expects('getChallenge')->twice()->andReturn( new Challenge(
+            $mock->expects('isDisabled')->andReturnFalse();
+            $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
+            $mock->expects('getChallenge')->andReturn( new Challenge(
                 false, '', '', '', [], [], new Carbon()
             ));
         });
 
-        $this->post('test', [Turnstile::KEY => 'fail'])
-            ->assertSessionHasErrors([
-                Turnstile::KEY => 'The Cloudflare Turnstile challenge is invalid, absent, or has failed.'
-            ])
-            ->assertRedirect('/');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The Cloudflare Turnstile challenge is invalid, absent, or has failed.');
 
-        $this->postJson('test', [Turnstile::KEY => 'fail'])
-            ->assertStatus(422)
-            ->assertJsonValidationErrors([
-                Turnstile::KEY => 'The Cloudflare Turnstile challenge is invalid, absent, or has failed.'
-            ]);
+        TurnstileRequest::create(uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'invalid'])
+            ->setContainer($this->app)
+            ->setRedirector($this->app->make('redirect'))
+            ->validateResolved();
+    }
+
+    public function test_request_json_throws_validation_error_on_failed_challenge(): void
+    {
+        $this->mock(Turnstile::class, function (MockInterface $mock) {
+            $mock->expects('isDisabled')->andReturnFalse();
+            $mock->expects('rules')->andReturn([Turnstile::KEY => 'turnstile']);
+            $mock->expects('getChallenge')->andReturn( new Challenge(
+                false, '', '', '', [], [], new Carbon()
+            ));
+        });
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The Cloudflare Turnstile challenge is invalid, absent, or has failed.');
+
+        TurnstileRequest::create(uri: '/', method: 'POST', server: [
+            'CONTENT_TYPE' => 'application/json',
+        ], content: json_encode([Turnstile::KEY => 'invalid']))
+            ->setContainer($this->app)
+            ->setRedirector($this->app->make('redirect'))
+            ->validateResolved();
+    }
+
+    public function test_metadata(): void
+    {
+        $request = TurnstileRequest::create(
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+        )->setContainer($this->app);
+
+        $request->validateResolved();
+
+        $this->app->instance(
+            Challenge::class, new Challenge(true, '', '', '', ['foo' => ['bar' => 'baz']], [], new Carbon())
+        );
+
+        static::assertSame('baz', $request->metadata('foo.bar'));
+    }
+
+    public function test_action(): void
+    {
+        $request = TurnstileRequest::create(
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+        )->setContainer($this->app);
+
+        $request->validateResolved();
+
+        $this->app->instance(
+            Challenge::class, new Challenge(true, '', 'test_action', '', [], [], new Carbon())
+        );
+
+        static::assertTrue($request->isAction('test_action'));
+        static::assertFalse($request->isNotAction('test_action'));
+    }
+
+    public function test_customer_data(): void
+    {
+        $request = TurnstileRequest::create(
+            uri: '/', method: 'POST', parameters: [Turnstile::KEY => 'test_key']
+        )->setContainer($this->app);
+
+        $request->validateResolved();
+
+        $this->app->instance(
+            Challenge::class, new Challenge(true, '', '', 'test_cdata', [], [], new Carbon())
+        );
+
+        static::assertTrue($request->isCustomerData('test_cdata'));
+        static::assertFalse($request->isNotCustomerData('test_cdata'));
     }
 }


### PR DESCRIPTION
- Moves validation inside the `validateResolved()` method to allow _safer_ extensability.
- Adds additional helpers.