### PR TITLE
Include @csrf blade directive in interstitial view.

### DIFF
--- a/resources/views/interstitial.blade.php
+++ b/resources/views/interstitial.blade.php
@@ -350,6 +350,7 @@
                     {{ __('turnstile::interstitial.title') }}
                 </div>
                 <form id="form" method="post" class="min-h-[75px]">
+                    @csrf
                     <div class="flex justify-center">
                         <x-turnstile::widget data-action="interstitial" data-callback="submitForm" />
                     </div>


### PR DESCRIPTION
Without the @csrf directive and with CSRF protection enabled (Laravel default), interstitial form submission will produce error 419 'page expired'.