### PR TITLE
Remove @internal tags on interstitial middleware and controller.

### DIFF
--- a/src/Http/Controllers/InterstitialController.php
+++ b/src/Http/Controllers/InterstitialController.php
@@ -16,9 +16,6 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route as RouteFacade;
 use Laragear\Turnstile\Http\Requests\TurnstileRequest;
 
-/**
- * @internal
- */
 class InterstitialController extends Controller
 {
     /**

--- a/src/Http/Middleware/InterstitialMiddleware.php
+++ b/src/Http/Middleware/InterstitialMiddleware.php
@@ -12,9 +12,6 @@ use Illuminate\Routing\Redirector;
 use Illuminate\Support\DateFactory;
 use Illuminate\Support\Str;
 
-/**
- * @internal
- */
 class InterstitialMiddleware
 {
     /**


### PR DESCRIPTION
With the @internal tag set, PhpStorm will complain (strike-through notation) when middleware and controller get inserted in bootstrap/app.php and routes file.