### PR TITLE
Use CarbonInterface instead of Carbon

### DIFF
--- a/src/Challenge.php
+++ b/src/Challenge.php
@@ -4,7 +4,7 @@ namespace Laragear\Turnstile;
 
 use ErrorException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
 use function in_array;
@@ -17,7 +17,7 @@ use function in_array;
  * @property-read string $cdata
  * @property-read string $customer_data
  * @property-read string $c_data
- * @property-read \Illuminate\Support\Carbon $solved_at
+ * @property-read \Carbon\CarbonInterface $solved_at
  */
 readonly class Challenge
 {
@@ -33,7 +33,7 @@ readonly class Challenge
         public string $customerData,
         public array $metadata,
         public array $errors,
-        public Carbon $solvedAt,
+        public CarbonInterface $solvedAt,
     ) {
         // ...
     }
@@ -150,7 +150,7 @@ readonly class Challenge
      *
      * @throws \ErrorException
      */
-    public function __get(string $name): Carbon|string|bool
+    public function __get(string $name): CarbonInterface|string|bool
     {
         return match ($name) {
             'success' => $this->successful,


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "[X.x] This new feature"
- Describe what the new feature enables
- Show a small code snippet of the new feature
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.

If you're a Sponsor, this PR will have priority review.
Not a Sponsor? Become one at https://github.com/sponsors/DarkGhostHunter
-->

# Description

When using Date::use(CarbonImmutable::class); in the application, Laravel uses CarbonImmutable by default. Than the Challange fails to resolve.

# Code samples

in AppServiceProvider:
```php
use Carbon\CarbonImmutable;
use Illuminate\Support\Facades\Date;

Date::use(CarbonImmutable::class);
```
