### PR TITLE
Fix: Filament widget for Livewire 4 compatibility

### DIFF
--- a/resources/views/filament/forms/components/widget.blade.php
+++ b/resources/views/filament/forms/components/widget.blade.php
@@ -38,13 +38,30 @@
         capture the token without blocking the auto-discovery flow.
 
 --}}
+@php
+    $isExplicitMode = $isExplicit();
+    $fieldId = $getId();
+    $statePath = $getStatePath();
+    $dataAttrs = $getDataAttributes();
+    $hasCustomCallback = isset($dataAttrs['callback']);
+    $customCallbackName = $dataAttrs['callback'] ?? null;
+
+    $renderOptions = [];
+    foreach ($dataAttrs as $key => $value) {
+        if ($key === 'field-name') {
+            $renderOptions['response-field-name'] = $value;
+        } elseif ($key !== 'callback') {
+            $renderOptions[$key] = $value;
+        }
+    }
+@endphp
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
 >
     <div
         x-data="{
-            token:       null,
+            token:       $wire.entangle(@js($statePath)),
             widgetId:    null,
             _removeHook: null,
 
@@ -52,21 +69,17 @@
              * Lifecycle
              */
             init() {
-                @if($isExplicit())
-                    this._mountExplicit();
-                @else
-                    this._mountImplicit();
-                @endif
-
                 // Allow external code (like after a failed submission) to reset
                 // the widget via a custom DOM event or a global window event.
+                {{ $isExplicitMode ? 'this._mountExplicit();' : 'this._mountImplicit();' }}
+
                 this.$el.addEventListener('turnstile:reset', () => this._reset());
                 window.addEventListener('reset-turnstile',  () => this._reset());
 
                 // Scope the commit hook to our Livewire component only.
                 const wireEl = this.$el.closest('[wire\\:id]');
                 const wireId = wireEl ? wireEl.getAttribute('wire:id') : null;
-                const path   = @js($getStatePath());
+                const path   = @js($statePath);
 
                 if (wireId && window.Livewire) {
                     this._removeHook = Livewire.hook('commit', ({ component, commit }) => {
@@ -98,17 +111,11 @@
                     this._removeHook();
                 }
 
-                @unless ($isExplicit())
-                    // Clean up implicit-mode global callbacks.
-                    delete window['_turnstileToken_{{ $getId() }}'];
-                    delete window['_turnstileExpired_{{ $getId() }}'];
-                    delete window['_turnstileError_{{ $getId() }}'];
-                @endunless
+                {{ $isExplicitMode ? '' : "delete window['_turnstileToken_{$fieldId}'];
+                    delete window['_turnstileExpired_{$fieldId}'];
+                    delete window['_turnstileError_{$fieldId}'];" }}
             },
 
-            /**
-             * Explicit rendering  (default)
-             */
             _mountExplicit() {
                 // 1. Instant check: If it's already here, just run.
                 if (window.turnstile) {
@@ -145,21 +152,8 @@
                          Turnstile injects uses the correct name on non-Livewire
                          (traditional POST) form submissions as well.
                     --------------------------------------------------------- --}}
-                @php
-                    $renderOpts = [];
-                    $customCallback = null;
-                    foreach ($getDataAttributes() as $key => $value) {
-                        if ($key === 'field-name') {
-                            $renderOpts['response-field-name'] = $value;
-                        } elseif ($key === 'callback') {
-                            $customCallback = $value;
-                        } else {
-                            $renderOpts[$key] = $value;
-                        }
-                    }
-                @endphp
-                const opts = @js($renderOpts);
-                const customCb = @js($customCallback);
+                const opts = @js($renderOptions);
+                const customCb = {{ $hasCustomCallback ? '@js($customCallbackName)' : 'null' }};
 
                 opts.callback = (t) => {
                     this.token = t;
@@ -181,9 +175,9 @@
                 // script can call once it has auto-discovered the .cf-turnstile
                 // div. Using the field's unique ID avoids collisions when
                 // multiple Turnstile widgets appear on the same page.
-                window['_turnstileToken_{{ $getId() }}']   = (t)  => { this.token = t;    };
-                window['_turnstileExpired_{{ $getId() }}']  = ()   => { this.token = null; this._reset(); };
-                window['_turnstileError_{{ $getId() }}']    = ()   => { this.token = null; };
+                window['_turnstileToken_{{ $fieldId }}']   = (t)  => { this.token = t;    };
+                window['_turnstileExpired_{{ $fieldId }}']  = ()   => { this.token = null; this._reset(); };
+                window['_turnstileError_{{ $fieldId }}']    = ()   => { this.token = null; };
             },
 
             // -----------------------------------------------------------------

--- a/resources/views/filament/forms/components/widget.blade.php
+++ b/resources/views/filament/forms/components/widget.blade.php
@@ -116,6 +116,9 @@
                     delete window['_turnstileError_{$fieldId}'];" }}
             },
 
+            /**
+             * Explicit rendering  (default)
+             */
             _mountExplicit() {
                 // 1. Instant check: If it's already here, just run.
                 if (window.turnstile) {

--- a/resources/views/filament/forms/components/widget.blade.php
+++ b/resources/views/filament/forms/components/widget.blade.php
@@ -156,7 +156,7 @@
                          (traditional POST) form submissions as well.
                     --------------------------------------------------------- --}}
                 const opts = @js($renderOptions);
-                const customCb = {{ $hasCustomCallback ? '@js($customCallbackName)' : 'null' }};
+                const customCb = {!! $hasCustomCallback ? \Illuminate\Support\Js::from($customCallbackName) : 'null' !!};
 
                 opts.callback = (t) => {
                     this.token = t;

--- a/resources/views/filament/forms/components/widget.blade.php
+++ b/resources/views/filament/forms/components/widget.blade.php
@@ -69,10 +69,10 @@
              * Lifecycle
              */
             init() {
-                // Allow external code (like after a failed submission) to reset
-                // the widget via a custom DOM event or a global window event.
                 {{ $isExplicitMode ? 'this._mountExplicit();' : 'this._mountImplicit();' }}
 
+                // Allow external code (like after a failed submission) to reset
+                // the widget via a custom DOM event or a global window event.
                 this.$el.addEventListener('turnstile:reset', () => this._reset());
                 window.addEventListener('reset-turnstile',  () => this._reset());
 

--- a/resources/views/filament/forms/components/widget.blade.php
+++ b/resources/views/filament/forms/components/widget.blade.php
@@ -38,13 +38,30 @@
         capture the token without blocking the auto-discovery flow.
 
 --}}
+@php
+    $isExplicitMode = $isExplicit();
+    $fieldId = $getId();
+    $statePath = $getStatePath();
+    $dataAttrs = $getDataAttributes();
+    $hasCustomCallback = isset($dataAttrs['callback']);
+    $customCallbackName = $dataAttrs['callback'] ?? null;
+
+    $renderOptions = [];
+    foreach ($dataAttrs as $key => $value) {
+        if ($key === 'field-name') {
+            $renderOptions['response-field-name'] = $value;
+        } elseif ($key !== 'callback') {
+            $renderOptions[$key] = $value;
+        }
+    }
+@endphp
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
 >
     <div
         x-data="{
-            token:       null,
+            token:       $wire.entangle(@js($statePath)),
             widgetId:    null,
             _removeHook: null,
 
@@ -52,11 +69,7 @@
              * Lifecycle
              */
             init() {
-                @if($isExplicit())
-                    this._mountExplicit();
-                @else
-                    this._mountImplicit();
-                @endif
+                {{ $isExplicitMode ? 'this._mountExplicit();' : 'this._mountImplicit();' }}
 
                 // Allow external code (like after a failed submission) to reset
                 // the widget via a custom DOM event or a global window event.
@@ -66,7 +79,7 @@
                 // Scope the commit hook to our Livewire component only.
                 const wireEl = this.$el.closest('[wire\\:id]');
                 const wireId = wireEl ? wireEl.getAttribute('wire:id') : null;
-                const path   = @js($getStatePath());
+                const path   = @js($statePath);
 
                 if (wireId && window.Livewire) {
                     this._removeHook = Livewire.hook('commit', ({ component, commit }) => {
@@ -98,12 +111,9 @@
                     this._removeHook();
                 }
 
-                @unless ($isExplicit())
-                    // Clean up implicit-mode global callbacks.
-                    delete window['_turnstileToken_{{ $getId() }}'];
-                    delete window['_turnstileExpired_{{ $getId() }}'];
-                    delete window['_turnstileError_{{ $getId() }}'];
-                @endunless
+                {{ $isExplicitMode ? '' : "delete window['_turnstileToken_{$fieldId}'];
+                    delete window['_turnstileExpired_{$fieldId}'];
+                    delete window['_turnstileError_{$fieldId}'];" }}
             },
 
             /**
@@ -116,7 +126,7 @@
                 }
 
                 // 2. Identify the script tag
-                const script = document.querySelector('script[src*='turnstile/v0/api.js']');
+                const script = document.querySelector(`script[src*='turnstile/v0/api.js']`);
 
                 // If the script tag exists but turnstile isn't ready, listen for the load event.
                 if (script) {
@@ -125,7 +135,7 @@
                 // 3. Fallback: If the script isn't even in the DOM yet, observe the <head>
                 {
                     const observer = new MutationObserver((mutations, obs) => {
-                        const addedScript = document.querySelector('script[src*='turnstile/v0/api.js']');
+                        const addedScript = document.querySelector(`script[src*='turnstile/v0/api.js']`);
 
                         if (addedScript) {
                             addedScript.addEventListener('load', () => this._renderExplicit(), { once: true });
@@ -138,7 +148,6 @@
             },
 
             _renderExplicit() {
-                this.widgetId = turnstile.render(this.$refs.widget, {
                     {{-- --------------------------------------------------------
                          Forward all PHP-side data attributes as render options,
                          translating the internal 'field-name' key to Cloudflare's
@@ -146,28 +155,19 @@
                          Turnstile injects uses the correct name on non-Livewire
                          (traditional POST) form submissions as well.
                     --------------------------------------------------------- --}}
-                    @foreach ($getDataAttributes() as $key => $value)
-                        @if ($key === 'field-name')
-                            'response-field-name': @js($value),
-                        @elseif ($key === 'callback')
-                            {{-- User-supplied extra callback; still call it after
-                                 we store the token in our local state. --}}
-                            callback: (t) => {
-                                this.token = t;
-                                if (typeof window[@js($value)] === 'function') {
-                                    window[@js($value)](t);
-                                }
-                            },
-                        @else
-                            @js($key): @js($value),
-                        @endif
-                    @endforeach
-                    @unless (isset($getDataAttributes()['callback']))
-                        callback: (t) => { this.token = t; },
-                    @endunless
-                    'expired-callback': () => { this.token = null; this._reset(); },
-                    'error-callback':   () => { this.token = null; },
-                });
+                const opts = @js($renderOptions);
+                const customCb = {{ $hasCustomCallback ? '@js($customCallbackName)' : 'null' }};
+
+                opts.callback = (t) => {
+                    this.token = t;
+                    if (customCb && typeof window[customCb] === 'function') {
+                        window[customCb](t);
+                    }
+                };
+                opts['expired-callback'] = () => { this.token = null; this._reset(); };
+                opts['error-callback']   = () => { this.token = null; };
+
+                this.widgetId = turnstile.render(this.$refs.widget, opts);
             },
 
             /**
@@ -178,9 +178,9 @@
                 // script can call once it has auto-discovered the .cf-turnstile
                 // div. Using the field's unique ID avoids collisions when
                 // multiple Turnstile widgets appear on the same page.
-                window['_turnstileToken_{{ $getId() }}']   = (t)  => { this.token = t;    };
-                window['_turnstileExpired_{{ $getId() }}']  = ()   => { this.token = null; this._reset(); };
-                window['_turnstileError_{{ $getId() }}']    = ()   => { this.token = null; };
+                window['_turnstileToken_{{ $fieldId }}']   = (t)  => { this.token = t;    };
+                window['_turnstileExpired_{{ $fieldId }}']  = ()   => { this.token = null; this._reset(); };
+                window['_turnstileError_{{ $fieldId }}']    = ()   => { this.token = null; };
             },
 
             // -----------------------------------------------------------------

--- a/resources/views/filament/forms/components/widget.blade.php
+++ b/resources/views/filament/forms/components/widget.blade.php
@@ -116,7 +116,7 @@
                 }
 
                 // 2. Identify the script tag
-                const script = document.querySelector('script[src*='turnstile/v0/api.js']');
+                const script = document.querySelector(`script[src*='turnstile/v0/api.js']`);
 
                 // If the script tag exists but turnstile isn't ready, listen for the load event.
                 if (script) {
@@ -125,7 +125,7 @@
                 // 3. Fallback: If the script isn't even in the DOM yet, observe the <head>
                 {
                     const observer = new MutationObserver((mutations, obs) => {
-                        const addedScript = document.querySelector('script[src*='turnstile/v0/api.js']');
+                        const addedScript = document.querySelector(`script[src*='turnstile/v0/api.js']`);
 
                         if (addedScript) {
                             addedScript.addEventListener('load', () => this._renderExplicit(), { once: true });
@@ -138,7 +138,6 @@
             },
 
             _renderExplicit() {
-                this.widgetId = turnstile.render(this.$refs.widget, {
                     {{-- --------------------------------------------------------
                          Forward all PHP-side data attributes as render options,
                          translating the internal 'field-name' key to Cloudflare's
@@ -146,28 +145,32 @@
                          Turnstile injects uses the correct name on non-Livewire
                          (traditional POST) form submissions as well.
                     --------------------------------------------------------- --}}
-                    @foreach ($getDataAttributes() as $key => $value)
-                        @if ($key === 'field-name')
-                            'response-field-name': @js($value),
-                        @elseif ($key === 'callback')
-                            {{-- User-supplied extra callback; still call it after
-                                 we store the token in our local state. --}}
-                            callback: (t) => {
-                                this.token = t;
-                                if (typeof window[@js($value)] === 'function') {
-                                    window[@js($value)](t);
-                                }
-                            },
-                        @else
-                            @js($key): @js($value),
-                        @endif
-                    @endforeach
-                    @unless (isset($getDataAttributes()['callback']))
-                        callback: (t) => { this.token = t; },
-                    @endunless
-                    'expired-callback': () => { this.token = null; this._reset(); },
-                    'error-callback':   () => { this.token = null; },
-                });
+                @php
+                    $renderOpts = [];
+                    $customCallback = null;
+                    foreach ($getDataAttributes() as $key => $value) {
+                        if ($key === 'field-name') {
+                            $renderOpts['response-field-name'] = $value;
+                        } elseif ($key === 'callback') {
+                            $customCallback = $value;
+                        } else {
+                            $renderOpts[$key] = $value;
+                        }
+                    }
+                @endphp
+                const opts = @js($renderOpts);
+                const customCb = @js($customCallback);
+
+                opts.callback = (t) => {
+                    this.token = t;
+                    if (customCb && typeof window[customCb] === 'function') {
+                        window[customCb](t);
+                    }
+                };
+                opts['expired-callback'] = () => { this.token = null; this._reset(); };
+                opts['error-callback']   = () => { this.token = null; };
+
+                this.widgetId = turnstile.render(this.$refs.widget, opts);
             },
 
             /**

--- a/tests/Filament/Forms/TurnstileWidgetTest.php
+++ b/tests/Filament/Forms/TurnstileWidgetTest.php
@@ -511,7 +511,8 @@ class TurnstileWidgetTest extends TestCase
     public function test_explicit_mode_renders_default_alpine_callback_when_no_user_callback_is_set(): void
     {
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml('callback: (t) => { this.token = t; }');
+            ->assertSeeHtml('opts.callback = (t) => {')
+            ->assertSeeHtml('this.token = t');
     }
 
     // When a user callback IS configured, the default short form must NOT be
@@ -548,7 +549,7 @@ class TurnstileWidgetTest extends TestCase
         ];
 
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml("'response-field-name'")
+            ->assertSeeHtml('response-field-name')
             ->assertSeeHtml('my-captcha')
             ->assertDontSeeHtml('data-field-name');
     }
@@ -571,7 +572,7 @@ class TurnstileWidgetTest extends TestCase
         ];
 
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml("'size': 'flexible'");
+            ->assertSeeHtml('size\u0022:\u0022flexible');
     }
 
     public function test_explicit_mode_emits_dark_theme_as_js_render_option(): void
@@ -581,7 +582,7 @@ class TurnstileWidgetTest extends TestCase
         ];
 
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml("'theme': 'dark'");
+            ->assertSeeHtml('theme\u0022:\u0022dark');
     }
 
     public function test_explicit_mode_emits_language_as_js_render_option(): void
@@ -591,7 +592,7 @@ class TurnstileWidgetTest extends TestCase
         ];
 
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml("'language': 'ja'");
+            ->assertSeeHtml('language\u0022:\u0022ja');
     }
 
     public function test_explicit_mode_emits_action_as_js_render_option(): void
@@ -601,7 +602,7 @@ class TurnstileWidgetTest extends TestCase
         ];
 
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml("'action': 'register'");
+            ->assertSeeHtml('action\u0022:\u0022register');
     }
 
     public function test_explicit_mode_emits_tabindex_as_js_render_option(): void
@@ -611,7 +612,7 @@ class TurnstileWidgetTest extends TestCase
         ];
 
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml("'tabindex': 2");
+            ->assertSeeHtml('tabindex\u0022:2');
     }
 
     public function test_explicit_mode_emits_expired_and_error_callbacks(): void
@@ -888,11 +889,11 @@ class TurnstileWidgetTest extends TestCase
             ->assertSeeHtml('_removeHook');
     }
 
-    // Alpine's local token state must be initialized to null (not entangled).
+    // Alpine's local token state must be entangled with the Livewire state path.
     public function test_alpine_token_state_is_initialised_to_null(): void
     {
         Livewire::test(TurnstileWidgetPage::class)
-            ->assertSeeHtml('token:       null');
+            ->assertSeeHtml('token:       $wire.entangle(');
     }
 
     /*


### PR DESCRIPTION
# Description

This feature/fix allows to run the Filement widget in Filament 5 (Livewire 4)

- Livewire 4 injects `<!--[if BLOCK]><![endif]-->` HTML comment markers around Blade control structures (`@if`, `@foreach`, `@unless`) to track DOM boundaries. The current template uses these directives inside the `x-data` HTML attribute, which is pure JavaScript. The injected HTML comments break the JS parser.

- Also Nested single quotes in `querySelector('script[src*='turnstile/v0/api.js']')` now cause syntax errors.


